### PR TITLE
pytz seems to be a dependency now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+pytz==2024.2
 sqlfluff==0.10.1
 dbt-postgres==1.0.3


### PR DESCRIPTION
Didn't look into this too closely, but adding to the `requirements.txt` fixed things for me. :-)